### PR TITLE
new operators on arduino 1.00

### DIFF
--- a/del_opv.cpp
+++ b/del_opv.cpp
@@ -16,12 +16,15 @@
 	License along with this library; if not, write to the Free Software
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
+// Arduino 1.04 contains an implementation for this.
+#if ARDUINO < 104
 
 #include <new>
 #include <cstdlib>
 #include <func_exception>
 
-// Arduino now defines this.
-//_UCXXEXPORT void operator delete[](void * ptr) throw(){
-//	free(ptr);
-//}
+_UCXXEXPORT void operator delete[](void * ptr) throw(){
+	free(ptr);
+}
+
+#endif

--- a/new_opv.cpp
+++ b/new_opv.cpp
@@ -16,14 +16,13 @@
 	License along with this library; if not, write to the Free Software
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
+// Arduino 1.04 contains an implementation for this.
+#if ARDUINO < 104
 
 #include <new>
 #include <cstdlib>
 #include <func_exception>
 
-
-// Arduino now defines this
-#if 0
 _UCXXEXPORT void* operator new[](std::size_t numBytes) throw(std::bad_alloc){
 	//C++ stardard 5.3.4.8 requires that a valid pointer be returned for
 	//a call to new(0). Thus:
@@ -36,4 +35,5 @@ _UCXXEXPORT void* operator new[](std::size_t numBytes) throw(std::bad_alloc){
 	}
 	return p;
 }
+
 #endif


### PR DESCRIPTION
Got caught out by an old arduino install. Since this was fixed in [1.04](https://github.com/arduino/Arduino/commit/141684d41062d64552b77943c89ca7b78efac0c6), and other files check for version 1, this seems sensible
