### PR TITLE
Fix up errors with avr-gcc >= 5 regarding C++14 traits behavior

### DIFF
--- a/istream
+++ b/istream
@@ -340,7 +340,8 @@ namespace std{
 
 	};
 	
-	template <class charT,class traits = char_traits<charT> > class _UCXXEXPORT basic_istream<charT,traits>::sentry {
+	template <class charT,class traits> 
+          class _UCXXEXPORT basic_istream<charT,traits>::sentry {
 		bool ok;
 	public:
 		explicit _UCXXEXPORT sentry(basic_istream<charT,traits>& os, bool noskipws = false){

--- a/ostream
+++ b/ostream
@@ -314,7 +314,7 @@ namespace std {
 #endif
 #endif
 
-	template <class charT,class traits = char_traits<charT> >
+	template <class charT,class traits>
 		class _UCXXEXPORT basic_ostream<charT,traits>::sentry
 	{
 		bool ok;


### PR DESCRIPTION
Hi there,

thanks for porting uClibc++ to Arduino, we are using it at the [Hiveeyes](https://hiveeyes.org/) project. Cheers!
Yesterday, we experienced errors when trying to compile with avr-gcc 5.3.

We found the commit [istream, ostream: Fix building with g++ >= 5](https://git.busybox.net/uClibc++/commit/?id=d841ce2fd) at the upstream uClibc++ library and backported it to StandardCplusplus. This mitigated the problem using the `-std=gnu++14` compiler flag with avr-gcc => 5 and still compiles on avr-gcc 4.9 using `-std=gnu++11`.

With kind regards,
Andreas.
