### PR TITLE
Undefine cstdlib::abs before re-defining it

### DIFF
--- a/cstdlib
+++ b/cstdlib
@@ -57,6 +57,9 @@ namespace std{
 	using ::wcstombs;
 #endif
 
+// Undefine `abs`, because Arduino already has it.
+// https://github.com/maniacbug/StandardCplusplus/issues/2#issuecomment-32912640
+#undef abs
 	inline long abs(long i){
 		return labs(i);
 	}


### PR DESCRIPTION
Apparently, more recent Arduino versions already define the `cstdlib::abs` function. Let's undefine it, as suggested by @eric-wieser, in order to mitigate the [`expected unqualified-id before 'long'` build error](https://github.com/maniacbug/StandardCplusplus/issues/2#issuecomment-32912640).
